### PR TITLE
removed special case for MS JVM

### DIFF
--- a/src/Model.java
+++ b/src/Model.java
@@ -104,11 +104,6 @@ public class Model {
 					// Load the specified database driver
 					Class.forName(driverName);
 
-					// Driver is for Oracle 12cR1 (certified with JDK 7 and JDK
-					// 8)
-					if (java.lang.System.getProperty("java.vendor").equals("Microsoft Corp.")) {
-						DriverManager.registerDriver(new oracle.jdbc.driver.OracleDriver());
-					}
 				} else {
 
 					connection.close();


### PR DESCRIPTION
When was the last time anyone used [MS JVM](https://en.wikipedia.org/wiki/Microsoft_Java_Virtual_Machine)?

> In 2001, Microsoft settled the lawsuit with Sun and discontinued its Java implementation.